### PR TITLE
downgrade golang:1.20.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM golang:1.20.5
+FROM golang:1.20.4

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,16 +3,13 @@ version: "2.4"
 
 services:
   sut:
-    image: golang:1.20.5
+    image: golang:1.20.4
     volumes:
       - .:/go/src/github.com/balena-io/sshproxy
     working_dir: /go/src/github.com/balena-io/sshproxy
     entrypoint:
       - /bin/bash
       - "-c"
-    environment:
-      # make static binary
-      CGO_ENABLED: 0
     command:
       - |
         set -axe


### PR DESCRIPTION
build a dynamic binary against `GLIBC 2.31` to maintain compatibility with balena-proxy running `debian:bullseye`