### PR TITLE
Remove runner distro requirement from build and test

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -18,6 +18,7 @@ runs:
   steps:
     - shell: bash
       run: |
+        docker compose -f docker-compose.test.yml build
         docker compose -f docker-compose.test.yml run sut \
           'git config --global --add safe.directory $(pwd); make -j $(nproc) dep release'
 

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -20,14 +20,3 @@ jobs:
         github.event_name == 'pull_request_target'
       )
     secrets: inherit
-    with:
-      docker_images: ""
-      # open-balena-base/GLIBC compatibility
-      custom_test_matrix: >
-        {
-          "os": [["ubuntu-20.04"]]
-        }
-      docker_runs_on: |
-        {
-          "linux/amd64": ["ubuntu-20.04"]
-        }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,3 @@
-FROM golang:1.23.5
+
+# retain GLIBC compatibility with debian:bookworm used by open-balena-base
+FROM golang:1.23.5-bookworm

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,9 +1,8 @@
----
-version: "2.4"
 
 services:
   sut:
-    image: golang:1.23.5
+    build: .
+    image: sut
     volumes:
       - .:/go/src/github.com/balena-io/sshproxy
     working_dir: /go/src/github.com/balena-io/sshproxy


### PR DESCRIPTION
Ubuntu Focal 20.04 is EOL in May 2025 and open-balena-base
has been based on Debian Bookworm since July 2023.

Since we are building in a golang bookworm container for GLIBC
compatibility anyway, there is no need to limit the runners to
any specific distro.

See: https://balena.fibery.io/Work/Project/Ubuntu-20.04-hosted-runner-image-is-closing-down-1147
See: https://github.com/balena-io-modules/open-balena-base/pull/306
See: https://github.com/balena-io/sshproxy/pull/95
