### PR TITLE
Remove DSA host key loading

### DIFF
--- a/main.go
+++ b/main.go
@@ -189,7 +189,7 @@ func main() {
 	if viper.GetInt("idle-timeout") > 0 {
 		server.IdleTimeout = time.Duration(viper.GetInt("idle-timeout"))
 	}
-	for _, keyType := range []string{"ed25519", "rsa", "ecdsa", "dsa"} {
+	for _, keyType := range []string{"ed25519", "rsa", "ecdsa"} {
 		if err := addHostKey(&server, viper.GetString("dir"), keyType); err != nil {
 			fmt.Fprintf(os.Stderr, "%s", err)
 			os.Exit(2)


### PR DESCRIPTION
DSA/ssh-dss is deprecated and widely disabled by modern SSH clients due to its weak 1024-bit key size and SHA-1 based signature scheme. Stop loading id_dsa host keys and keep host key support limited to ed25519, rsa, and ecdsa.

We have recently removed DSA key generation related to this incident related to OpenSSH 10 dropping support for DSA keys: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/Console-pod-not-coming-online-209 

Change-type: major